### PR TITLE
POC of error handling

### DIFF
--- a/json/cheshire/clj_easy/tools/json/v0.clj
+++ b/json/cheshire/clj_easy/tools/json/v0.clj
@@ -1,9 +1,13 @@
 (ns clj-easy.tools.json.v0
-  (:require [cheshire.core :as cheshire]))
+  (:require [cheshire.core :as cheshire])
+  (:import (com.fasterxml.jackson.core.io JsonEOFException)))
 
 (defn read-str
   ([s] (read-str s nil))
-  ([s {:keys [key-fn]}] (cheshire/parse-string s (or key-fn keyword))))
+  ([s {:keys [key-fn]}]
+   (try (cheshire/parse-string s (or key-fn keyword))
+     (catch JsonEOFException e
+       (throw (ex-info "Incomplete input" {} e))))))
 
 (defn write-str
   ([s] (write-str s nil))

--- a/json/data-json/clj_easy/tools/json/v0.clj
+++ b/json/data-json/clj_easy/tools/json/v0.clj
@@ -3,8 +3,11 @@
 
 (defn read-str
   ([s] (read-str s nil))
-  ([s {:keys [key-fn]}] (json/read-str s :key-fn (or key-fn keyword))))
-
+  ([s {:keys [key-fn]}]
+   (try (json/read-str s :key-fn (or key-fn keyword))
+     (catch Exception e
+       (throw (ex-info "Incomplete input" {} e))))))
+         
 (defn write-str
   ([s] (write-str s nil))
   ([s _opts] (json/write-str s)))

--- a/test/clj_easy/tools/json_test.clj
+++ b/test/clj_easy/tools/json_test.clj
@@ -7,7 +7,10 @@
     (is (= [1 2 3] (json/read-str "[1, 2, 3]")))
     (is (= {:a 1} (json/read-str "{\"a\": 1}")))
     (is (= {:a 1} (json/read-str "{\"a\": 1}" {:key-fn keyword})))
-    (is (= {"a" 1} (json/read-str "{\"a\": 1}" {:key-fn str}))))
+    (is (= {"a" 1} (json/read-str "{\"a\": 1}" {:key-fn str})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+          #"Incomplete input"
+          (json/read-str "{\"a\": 1" {:key-fn str}))))
   (testing "write json"
     (is (= [1 2 3] (json/read-str (json/write-str [1 2 3]))))
     (is (= {:a 1} (json/read-str (json/write-str {:a 1}))))))


### PR DESCRIPTION
This is only a poc of how I suggest we handle errors. Here we catch and rethrow an `ex-info` with the original exception as the cause. If the user only uses the top level exception they can replace implementations without having to redo the error handling on the application.

WDYT?